### PR TITLE
docs(workflow): lock branch and merge policy for clean graph

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,10 @@
 - After each approved implementation step, stop and wait for explicit user approval before continuing.
 - For every newly approved feature idea, create a dedicated `docs/ideas/<idea-name>.md` file before implementation starts.
 - The idea file must contain state-based execution steps, acceptance criteria, assumptions, and out-of-scope items; implementation must continuously reference that file to avoid drift.
-- Never create commits on `main` directly; all code changes must be committed on a non-`main` branch and merged via PR.
+- Never create commits on `main` directly.
+- Feature work must start on a non-`main` branch.
+- Integration from feature branches into `develop` does not require PR and must use squash integration.
+- Integration from `develop` into `main` must always use PR with a merge commit (no squash, no rebase).
 - Never watch GitHub pipelines by default. After triggering CI/CD, ask the user to check status unless the user explicitly asks for monitoring.
 
 ## Product Direction
@@ -66,8 +69,22 @@ After feature implementation is finished, follow this exact sequence:
 - Create/use a feature branch.
 - Commit the finalized feature changes on that branch.
 
-5. Develop Merge Gate
-- Prepare and execute merge to `develop` via PR workflow.
+5. Develop Integration Gate
+- Integrate the feature branch into `develop` without PR.
+- Use squash integration so each feature appears as one integration commit on `develop`.
+- Delete the feature branch after successful integration.
 
 6. Main Merge Gate
-- After develop stabilization, prepare and execute merge to `main` via PR workflow.
+- Merge `develop` into `main` only via PR.
+- PR merge strategy must be `Create a merge commit` (no squash, no rebase).
+
+7. Post-Main Sync Gate
+- Immediately sync `develop` with `main` after the `main` merge so no long-lived divergence remains.
+
+## Git Graph Policy (Mandatory)
+
+- Long-lived branches are only `develop` and `main`.
+- Temporary branches are allowed only for active feature work and must be deleted after integration.
+- Do not introduce release/integration branch chains unless explicitly approved by the user.
+- Keep history linear on `develop` by squash-integrating feature work.
+- Keep release history explicit on `main` using PR merge commits from `develop`.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -271,11 +271,25 @@ After implementation completes, this sequence is mandatory for every feature:
 4. Feature Branch + Commit Gate
 - Finalized changes are committed on a feature branch (never directly on `main`).
 
-5. Develop Merge Gate
-- Merge to `develop` is prepared and executed via PR workflow.
+5. Develop Integration Gate
+- Integrate feature branch work into `develop` without PR.
+- Use squash integration so each feature becomes one integration commit on `develop`.
+- Delete the feature branch after successful integration.
 
 6. Main Merge Gate
-- After develop stabilization, merge to `main` is prepared and executed via PR workflow.
+- Merge `develop` into `main` only via PR.
+- PR merge strategy must be `Create a merge commit` (no squash, no rebase).
+
+7. Post-Main Sync Gate
+- Immediately sync `develop` with `main` after `main` merge so long-lived divergence does not accumulate.
+
+## Git Graph Rules (Locked)
+
+- Only `develop` and `main` are long-lived branches.
+- Temporary branches are feature-only and must be removed after integration.
+- Release/integration branch chains are not used unless explicitly approved by the user.
+- `feature/* -> develop`: squash integration without PR.
+- `develop -> main`: PR required with merge commit.
 
 ## Historical Note
 


### PR DESCRIPTION
## Summary
- lock Git workflow policy in repository docs to keep graph clean and predictable
- enforce `feature/* -> develop` squash integration without PR
- enforce `develop -> main` PR-only with merge commit (no squash/no rebase)
- enforce immediate post-main sync from `main` back to `develop`

## Validation
- pre-commit formatting check passed
- pre-push quality gate passed (`0 warnings`, `0 errors`)
- test suite passed (`270 passed`, `0 failed`)
